### PR TITLE
Use newest Ubuntu 14.04 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.2
+FROM ubuntu:14.04
 
 MAINTAINER Maksym Bilenko <sath891@gmail.com>
 


### PR DESCRIPTION
By basing on 14.04, and not particular point version, we have always up-to-date base packages. Crucial from security point of view.