### PR TITLE
Use rlwrap to enable line editing in sqlplus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ADD init.ora /
 ADD initXETemp.ora /
 
 # Prepare to install Oracle
-RUN apt-get update && apt-get install -y -q libaio1 net-tools bc curl && \
+RUN apt-get update && apt-get install -y -q libaio1 net-tools bc curl rlwrap && \
 apt-get clean && \
 rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* &&\
 ln -s /usr/bin/awk /bin/awk &&\


### PR DESCRIPTION
The rlwrap provides following features missing in sqlplus:

* line editing
* command history
* tab completion (with plugins)

To make magic happen simply run the following (or make an alias)

    rlwrap sqlplus

More magic:
https://mikesmithers.wordpress.com/2013/07/06/simple-pleasures-rlwrap-and-sqlplus-command-line-editing-on-linux/