### PR TITLE
Handle passing arguments to docker-run command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,6 +62,6 @@ case "$1" in
 
 	*)
 		echo "Database is not configured. Please run /etc/init.d/oracle-xe configure if needed."
-		$1
+		exec "$@"
 		;;
 esac


### PR DESCRIPTION
This change will allow things like `docker run --link dbcontainer sath89/oracle-xe-11g sqlplus system/oracle@//dbcontainer:1521/xe` to work instead of dropping the argument to `sqlplus`.